### PR TITLE
Ext slices tests with objects + some refactoring

### DIFF
--- a/program_slicing/decomposition/block/extension/slicing.py
+++ b/program_slicing/decomposition/block/extension/slicing.py
@@ -188,7 +188,7 @@ def __flow_dep_given_data_dep(
         if variable_name is not None:
             return statement_2.name == variable_name
         return True
-    if statement_1.ast_subtype == "update_expression":
+    if statement_1.ast_node_type in {"update_expression", "+=", "-=", "/=", "*=", "%=", "&=", "|=", "^=", ">>=", "<<="}:
         return True
     return False
 
@@ -225,8 +225,7 @@ def __compute_backward_slice_recursive(
     for predecessor in set(chain(cdg_predecessors, flow_predecessors)):
         if predecessor in backward_slice:
             continue
-        if predecessor.statement_type == StatementType.FUNCTION or\
-         "formal_parameter" in predecessor.ast_node_type:
+        if predecessor.statement_type == StatementType.FUNCTION or "formal_parameter" in predecessor.ast_node_type:
             continue
         new_variable_name = None
         if predecessor in original_block:
@@ -341,9 +340,9 @@ def __filter_control_dependence(
     if new_statements is None or len(new_statements) == 0:
         return True
     missing_cdg_parents = set(reduce(
-                            lambda x, y: x.union(set(cdg.predecessors(y))),
-                            {x for x in original_statements if x.statement_type != StatementType.FUNCTION},
-                            set()))
+        lambda x, y: x.union(set(cdg.predecessors(y))),
+        {x for x in original_statements if x.statement_type != StatementType.FUNCTION},
+        set()))
     all_statements = new_statements.union(original_statements)
     for statement in new_statements:
         if statement.statement_type == StatementType.FUNCTION:

--- a/program_slicing/graph/parse/cdg_java.py
+++ b/program_slicing/graph/parse/cdg_java.py
@@ -790,6 +790,13 @@ def parse(source_code: str) -> ControlDependenceGraph:
     return result
 
 
+def __get_ass_subtype(ast: Node) -> str:
+    if ast.type == "update_expression":
+        return ast.type
+    if ast.children[1].type in {'+=', '-=', '/=', '*=', '%=', '&=', '|=', '^=', '>>=', '<<='}:
+        return "update_expression"
+    return None
+
 def __parse(
         source_code_bytes: bytes,
         ast: Node,
@@ -815,13 +822,17 @@ def __parse(
         start_point = __start_point
     if end_point is None:
         end_point = __end_point
+    statement_subtype = None
+    if statement_type == StatementType.ASSIGNMENT:
+        statement_subtype = __get_ass_subtype(ast)
     statement = Statement(
         statement_type,
         start_point=start_point,
         end_point=end_point,
         affected_by=__parse_affected_by(source_code_bytes, ast, variable_names),
         name=tree_sitter_parsers.node_name(source_code_bytes, ast),
-        ast_node_type=ast.type)
+        ast_node_type=ast.type,
+        ast_subtype = statement_subtype)
     cdg.add_node(statement)
     siblings, exit_points = statement_handler(
         statement,

--- a/program_slicing/graph/parse/cdg_java.py
+++ b/program_slicing/graph/parse/cdg_java.py
@@ -862,10 +862,11 @@ def __parse_undeclared_class(source_code_bytes: bytes, ast: Node, cdg: ControlDe
             cdg.add_entry_point(entry_point)
             entry_points = [entry_point]
             exit_statements = []
+            names = set()
             for parameter in node.children:
-                for child in __parse(source_code_bytes, parameter, cdg, entry_points, [], [], exit_statements, set()):
+                for child in __parse(source_code_bytes, parameter, cdg, entry_points, [], [], exit_statements, names):
                     cdg.add_edge(entry_point, child)
-            for child in __parse(source_code_bytes, scope, cdg, entry_points, [], [], exit_statements, set()):
+            for child in __parse(source_code_bytes, scope, cdg, entry_points, [], [], exit_statements, names):
                 cdg.add_edge(entry_point, child)
             exit_point = __add_exit_point(cdg, entry_point, entry_points + exit_statements)
             cdg.add_edge(entry_point, exit_point)

--- a/program_slicing/graph/parse/cdg_java.py
+++ b/program_slicing/graph/parse/cdg_java.py
@@ -790,13 +790,6 @@ def parse(source_code: str) -> ControlDependenceGraph:
     return result
 
 
-def __get_ass_subtype(ast: Node) -> str:
-    if ast.type == "update_expression":
-        return ast.type
-    if ast.children[1].type in {'+=', '-=', '/=', '*=', '%=', '&=', '|=', '^=', '>>=', '<<='}:
-        return "update_expression"
-    return None
-
 def __parse(
         source_code_bytes: bytes,
         ast: Node,

--- a/program_slicing/graph/parse/cdg_java.py
+++ b/program_slicing/graph/parse/cdg_java.py
@@ -154,7 +154,7 @@ def __handle_switch(
         start_point=switch_block_start_point,
         end_point=switch_block_end_point,
         affected_by=__parse_affected_by(source_code_bytes, switch_block_ast, variable_names),
-        ast_node_type=switch_block_ast.type)
+        ast_node_type=__parse_ast_node_type(switch_block_ast))
     siblings.append(block_statement)
     __route_control_flow(entry_points, block_statement, cdg)
     entry_points = [block_statement]
@@ -172,7 +172,7 @@ def __handle_switch(
                     StatementType.SCOPE,
                     start_point=switch_label_start_point,
                     end_point=switch_block_end_point,
-                    ast_node_type=switch_block_item_ast.type)
+                    ast_node_type=__parse_ast_node_type(switch_block_item_ast))
                 cdg.add_edge(statement, switch_label_statement)
                 __route_control_flow([statement], switch_label_statement, cdg)
                 __route_control_flow(entry_points, switch_label_statement, cdg)
@@ -239,7 +239,7 @@ def __handle_if(
             start_point=start_point,
             end_point=end_point,
             affected_by=set(),
-            ast_node_type=else_ast.type)
+            ast_node_type=__parse_ast_node_type(else_ast))
         cdg.add_edge(statement, else_statement)
         __route_control_flow(alternative_entry_points, else_statement, cdg)
         alternative_entry_points = [else_statement]
@@ -821,7 +821,7 @@ def __parse(
         end_point=end_point,
         affected_by=__parse_affected_by(source_code_bytes, ast, variable_names),
         name=tree_sitter_parsers.node_name(source_code_bytes, ast),
-        ast_node_type=ast.type)
+        ast_node_type=__parse_ast_node_type(ast))
     cdg.add_node(statement)
     siblings, exit_points = statement_handler(
         statement,
@@ -914,6 +914,12 @@ def __parse_undeclared_method(source_code_bytes: bytes, ast: Node, cdg: ControlD
 
 def __parse_statement_type_and_handler(ast: Node) -> Tuple[StatementType, Callable]:
     return statement_type_and_handler_map.get(ast.type, (StatementType.UNKNOWN, __handle_block))
+
+
+def __parse_ast_node_type(ast: Node) -> str:
+    if ast.type == "assignment_expression":
+        return ast.children[1].type
+    return ast.type
 
 
 def __parse_position_range(ast: Node) -> Tuple[Point, Point]:

--- a/program_slicing/graph/statement.py
+++ b/program_slicing/graph/statement.py
@@ -7,6 +7,8 @@ __date__ = '2021/03/23'
 from typing import Optional, Set
 from enum import Enum
 
+from tree_sitter import Node
+
 from program_slicing.graph.point import Point
 
 
@@ -35,13 +37,15 @@ class Statement:
             end_point: Point,
             affected_by: Set[VariableName] = None,
             name: Optional[VariableName] = None,
-            ast_node_type: str = None) -> None:
+            ast_node_type: str = None,
+            ast_subtype: str = None) -> None:
         self.__statement_type: StatementType = statement_type
         self.__start_point: Point = start_point
         self.__end_point: Point = end_point
         self.__affected_by: Set[VariableName] = set() if affected_by is None else affected_by
         self.__name: Optional[VariableName] = name
         self.__ast_node_type: str = ast_node_type
+        self.__ast_subtype = ast_subtype
 
     def __repr__(self) -> str:
         return \
@@ -51,12 +55,14 @@ class Statement:
             "name={name}, " \
             "affected_by={affected_by}, " \
             "start_point={start_point}, " \
+            "ast_subtype={ast_node}, "\
             "end_point={end_point})".format(
                 statement_type=self.__statement_type,
                 ast_node_type=self.__ast_node_type,
                 name=None if self.__name is None else "'" + self.__name + "'",
                 affected_by=self.__affected_by,
                 start_point=self.__start_point,
+                ast_subtype=self.__ast_subtype,
                 end_point=self.__end_point
             )
 
@@ -102,3 +108,8 @@ class Statement:
     @property
     def ast_node_type(self) -> str:
         return self.__ast_node_type
+
+    @property
+    def ast_subtype(self) -> str:
+        return self.__ast_subtype
+

--- a/program_slicing/graph/statement.py
+++ b/program_slicing/graph/statement.py
@@ -7,8 +7,6 @@ __date__ = '2021/03/23'
 from typing import Optional, Set
 from enum import Enum
 
-from tree_sitter import Node
-
 from program_slicing.graph.point import Point
 
 
@@ -37,15 +35,13 @@ class Statement:
             end_point: Point,
             affected_by: Set[VariableName] = None,
             name: Optional[VariableName] = None,
-            ast_node_type: str = None,
-            ast_subtype: str = None) -> None:
+            ast_node_type: str = None) -> None:
         self.__statement_type: StatementType = statement_type
         self.__start_point: Point = start_point
         self.__end_point: Point = end_point
         self.__affected_by: Set[VariableName] = set() if affected_by is None else affected_by
         self.__name: Optional[VariableName] = name
         self.__ast_node_type: str = ast_node_type
-        self.__ast_subtype = ast_subtype
 
     def __repr__(self) -> str:
         return \
@@ -106,8 +102,3 @@ class Statement:
     @property
     def ast_node_type(self) -> str:
         return self.__ast_node_type
-
-    @property
-    def ast_subtype(self) -> str:
-        return self.__ast_subtype
-

--- a/test/decomposition/block/extension/test_slicing.py
+++ b/test/decomposition/block/extension/test_slicing.py
@@ -684,12 +684,15 @@ class ExtendedBlockSlicingTestCase(unittest.TestCase):
             _range = [(r[0].line_number, r[1].line_number) for r in ext.ranges_compact]
             result_extension_ranges.append(_range)
         expected_extension_ranges = [
-            [(2, 5)]]
+            [(2, 6)],
+            [(4, 6)],
+            [(3, 6)],
+            [(2, 2), (4, 6)]]
         self.assertEqual(
             sorted(expected_extension_ranges),
             sorted(result_extension_ranges))
 
-    def test_get_block_extensions_7(self) -> None:
+    def test_get_block_extensions_8(self) -> None:
         code_ex = """
            public void methodEx(boolean a){
               int c = 1;
@@ -714,8 +717,33 @@ class ExtendedBlockSlicingTestCase(unittest.TestCase):
             sorted(expected_extension_ranges),
             sorted(result_extension_ranges))
 
+    def test_get_block_extensions_9(self) -> None:
+        code_ex = """
+        public void methodEx(final AClass a) {
+            final int opt = a.getOpt();
+            int i = 1;
+            if (opt > 0) {
+                if (i > 1) {
+                    for (int j = 0; j < opt; j++, i++) {
+                        System.out.println(opt);
+                    }
+                }
+            }
+        }"""
+        manager = ProgramGraphsManager(code_ex, Lang.JAVA)
+        block = manager.get_statements_in_range(Point(6, 0), Point(8, 10000))
+        result_extension_ranges = []
+        for ext in get_block_extensions(block, manager, code_ex.split("\n")):
+            _range = [(r[0].line_number, r[1].line_number) for r in ext.ranges_compact]
+            result_extension_ranges.append(_range)
+        expected_extension_ranges = [
+            [(6, 8)],
+            [(2, 10)]
+        ]
+        self.assertEqual(sorted(expected_extension_ranges), sorted(result_extension_ranges))
+
     @unittest.skip("Object DDG")
-    def test_get_block_extensions_8(self) -> None:
+    def test_get_block_extensions_10(self) -> None:
         code_ex = """
         public void methodEx(boolean a){
            RClass r = getR();
@@ -740,7 +768,7 @@ class ExtendedBlockSlicingTestCase(unittest.TestCase):
             sorted(result_extension_ranges))
 
     @unittest.skip("Object DDG")
-    def test_get_block_extensions_9(self) -> None:
+    def test_get_block_extensions_11(self) -> None:
         code_ex = """
             public void methodEx(LClass l){
                boolean a = l.getR();


### PR DESCRIPTION
- correct handling of `+=' type of operators (take care of data dependency)
- tests for data dependencies for objects (skipped for now)
- remove some obsolete tests
- simplify data structure for extensions
- correct ext slices for method formal parameters